### PR TITLE
Fix babel parsing plugins (typescript)

### DIFF
--- a/extract.js
+++ b/extract.js
@@ -133,9 +133,16 @@ function loadBabelOpts (opts) {
 		if (Array.isArray(fileOpts[key]) && !fileOpts[key].length) {
 			continue;
 		}
-		// because some options need to be passed to parser also
+		
 		opts[key] = fileOpts[key];
-		opts.parserOpts[key] = fileOpts[key];
+
+		if (Array.isArray(fileOpts[key]) && Array.isArray(opts.parserOpts[key])) {
+			// combine arrays for plugins
+			opts.parserOpts[key] = opts.parserOpts[key].concat(fileOpts[key]);
+		}	else {
+			// because some options need to be passed to parser also
+			opts.parserOpts[key] = fileOpts[key];
+		}
 	}
 	return opts;
 }


### PR DESCRIPTION
I was mystified as to why stylelint stopped working when I switched from .jsx to .tsx, and it turns out it was this. It was overriding that set of plugins with Babel's automatically detected ones, and if you had babel typescript installed in a gatsby plugin, which babel missed. I believe it may also fix it if you were using tsc and not babel. 

I imagine there are some other problems this might solve too though. Please give feedback! I'm happy to change things on request, especially if someone tests this and discovers that it spawns another bug.

> Which issue, if any, is this issue related to?

https://github.com/gucong3000/postcss-jsx/issues/55
This is closed but the fix for it broke on other cases, like mine. 

> Is there anything in the PR that needs further explanation?

I believe that by putting the babel options second, they'll override any conflicting plugins defined in the stylelint list there. If this isn't the case, then perhaps something more precise is required. 