### PR TITLE
Add experimental 'substitute' option, that will subtitute all template literals

### DIFF
--- a/substitute-javascript.js
+++ b/substitute-javascript.js
@@ -1,0 +1,75 @@
+'use strict';
+
+const literalsKey = Symbol('Literals');
+const replacementsKey = Symbol('Replaced properties');
+
+function addSubstitution(item, key, literals) {
+	item[replacementsKey] = item[replacementsKey] || [];
+
+	literals.forEach((literal) => {
+		const position = item[key].indexOf(literal);
+
+		if (position !== -1) {
+			const substitution = '$dummyValue' + position;
+
+			item[replacementsKey].push({
+				key,
+				original: literal,
+				substitution,
+			});
+
+			item[key] = item[key].replace(literal, substitution);
+		}
+	});
+}
+
+function addSubstitutions(node, css, opts) {
+	if (typeof node.walk !== 'function') return;
+
+	if (css && opts) {
+		const offset = opts.quasis[0].start;
+
+		node[literalsKey] = [];
+
+		opts.expressions.forEach(({ start, end }) => {
+			node[literalsKey].push('${' + css.substring(start - offset, end - offset) + '}');
+		});
+	}
+
+	if (!node[literalsKey]) return;
+
+	node.walk((item) => {
+		if (item.type === 'atrule') {
+			addSubstitution(item, 'name', node[literalsKey]);
+			addSubstitution(item, 'params', node[literalsKey]);
+		} else if (item.type === 'rule') {
+			addSubstitution(item, 'selector', node[literalsKey]);
+		} else if (item.type === 'decl') {
+			addSubstitution(item, 'prop', node[literalsKey]);
+			addSubstitution(item, 'value', node[literalsKey]);
+		} else if (item.type === 'root') {
+			addSubstitutions(item);
+		}
+	});
+}
+
+exports.addSubstitutions = addSubstitutions;
+
+exports.removeSubstitutions = (node) => {
+	if (typeof node.walk !== 'function') return;
+
+	node.walk((item) => {
+		if (!item[replacementsKey]) {
+			return;
+		}
+
+		item[replacementsKey].forEach((replacement) => {
+			item[replacement.key] = item[replacement.key].replace(
+				replacement.substitution,
+				replacement.original,
+			);
+		});
+
+		delete item[replacementsKey];
+	});
+};

--- a/template-parse.js
+++ b/template-parse.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Input = require('postcss/lib/input');
+const substitutions = require('./substitute-javascript');
 const TemplateParser = require('./template-parser');
 
 function templateParse(css, opts) {
@@ -12,6 +13,11 @@ function templateParse(css, opts) {
 	const parser = new TemplateParser(input);
 
 	parser.parse();
+
+	if (((opts.syntax.config.jsx || {}).config || opts.syntax.config).unstable_substitute) {
+		parser.root.unstable_substitute = true;
+		substitutions.addSubstitutions(parser.root, css, opts);
+	}
 
 	return parser.root;
 }

--- a/template-safe-parse.js
+++ b/template-safe-parse.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Input = require('postcss/lib/input');
+const substitutions = require('./substitute-javascript');
 const TemplateSafeParser = require('./template-safe-parser');
 
 function templateSafeParse(css, opts) {
@@ -12,6 +13,11 @@ function templateSafeParse(css, opts) {
 	const parser = new TemplateSafeParser(input);
 
 	parser.parse();
+
+	if (opts.syntax.config.unstable_substitute) {
+		parser.root.unstable_substitute = true;
+		substitutions.addSubstitutions(parser.root, css, opts);
+	}
 
 	return parser.root;
 }

--- a/template-stringify.js
+++ b/template-stringify.js
@@ -1,9 +1,18 @@
 'use strict';
 
+const substitutions = require('./substitute-javascript');
 const TemplateStringifier = require('./template-stringifier');
 
 module.exports = function TemplateStringify(node, builder) {
+	if (node.unstable_substitute) {
+		substitutions.removeSubstitutions(node);
+	}
+
 	const str = new TemplateStringifier(builder);
 
 	str.stringify(node);
+
+	if (node.unstable_substitute) {
+		substitutions.addSubstitutions(node);
+	}
 };


### PR DESCRIPTION
This (experimentally) solves #16.

When this package is used, now an option can be specified:

```js
// Before
const syntax = require('@stylelint/postcss-css-in-js')();

// After
const syntax = require('@stylelint/postcss-css-in-js')({ unstable_substitute: true });
```

This is marked explicitly as an experimental option, as the way this feature is implemented is probabily not the best way to do it, and existing implementations can fail on this option being set to `true`. This also makes it possible to change the behaviour of this option between semver-compatible releases.

The naming of `unstable_` is how Next.js also implements experimental features, which is why I named it like this (there are no existing options for this processor currently).

Even though this is probabily not the best way to build something like this, I would still propose to merge and release this. This makes it possible to run a lot of stylelint rules reliably - it only fails on generating good-looking error messages. For stylelint it will look like the template literals never existed.

------

_Merge request https://github.com/stylelint/stylelint/pull/4944 enables this as an unstable option in stylelint - its last commit can be used to easily test this out in your projects._