### PR TITLE
Fix computed property name in Object Styles

### DIFF
--- a/object-parser.js
+++ b/object-parser.js
@@ -239,6 +239,16 @@ class objectParser {
 				}
 
 				rule = atRule;
+			} else if (node.computed) {
+				// for computed property name
+
+				rule = postcss.rule({
+					selector: key.value,
+				});
+				// recalculate trivial spaces
+				const [prefix, postfix] = rawKey.split(key.value);
+
+				defineRaws(rule, 'selector', prefix, postfix);
 			} else {
 				// rule = this.rule(key, keyWrap, node.value, parent);
 				rule = postcss.rule({

--- a/object-parser.js
+++ b/object-parser.js
@@ -245,7 +245,7 @@ class objectParser {
 				rule = postcss.rule({
 					selector: key.value,
 				});
-				// recalculate trivial spaces
+				// recalculate trivial characters
 				const [prefix, postfix] = rawKey.split(key.value);
 
 				defineRaws(rule, 'selector', prefix, postfix);
@@ -279,6 +279,20 @@ class objectParser {
 			raw(atRule);
 
 			return atRule;
+		} else if (node.computed) {
+			// recalculate trivial characters
+			const [prefix, postfix] = rawKey.split(key.value);
+
+			const decl = postcss.decl({
+				prop: key.value,
+				value: value.value,
+			});
+
+			defineRaws(decl, 'prop', prefix, postfix);
+			defineRaws(decl, 'value', value.prefix, value.suffix);
+			raw(decl);
+
+			return decl;
 		} else {
 			let decl;
 

--- a/test/emotion.js
+++ b/test/emotion.js
@@ -15,7 +15,7 @@ describe('javascript tests', () => {
 		code = code.toString();
 
 		expect(document.toString()).toBe(code);
-		expect(document.nodes).toHaveLength(4);
+		expect(document.nodes).toHaveLength(5);
 
 		document.nodes.forEach((root) => {
 			expect(typeof root.last.toString()).toBe('string');
@@ -47,7 +47,7 @@ describe('javascript tests', () => {
 		code = code.toString();
 
 		expect(document.toString()).toBe(code);
-		expect(document.nodes).toHaveLength(6);
+		expect(document.nodes).toHaveLength(7);
 
 		document.nodes.forEach((root) => {
 			expect(typeof root.last.toString()).toBe('string');

--- a/test/fixtures/emotion-10.jsx
+++ b/test/fixtures/emotion-10.jsx
@@ -17,6 +17,8 @@ const YetAnotherComponent = styled.p(
 const AnotherComponent = styled.h1(
 	{
 		color: "hotpink",
+		[dynamicProp]: '4px',
+		[`${dynamicProp}-gap`]: '4px',
 		[YetAnotherComponent]: {
 			color: "white",
 		},

--- a/test/fixtures/emotion-10.jsx
+++ b/test/fixtures/emotion-10.jsx
@@ -8,9 +8,18 @@ const SomeComponent = styled.div`
 	background-color: ${props => props.color};
 `;
 
+const YetAnotherComponent = styled.p(
+	{
+		backgroundColor: "black",
+	}
+);
+
 const AnotherComponent = styled.h1(
 	{
 		color: "hotpink",
+		[YetAnotherComponent]: {
+			color: "white",
+		},
 	},
 	props => ({ flex: props.flex })
 );
@@ -28,6 +37,7 @@ render(
 			}}>
 				Some other text.
 			</span>
+			<YetAnotherComponent>Yet another text.</YetAnotherComponent>
 		</AnotherComponent>
 	</SomeComponent>
 );

--- a/test/fixtures/emotion-10.jsx
+++ b/test/fixtures/emotion-10.jsx
@@ -20,6 +20,12 @@ const AnotherComponent = styled.h1(
 		[YetAnotherComponent]: {
 			color: "white",
 		},
+		[`${YetAnotherComponent} > span`]: {
+			color: "black",
+		},
+		"&:before": {
+			content: `'!'`,
+		},
 	},
 	props => ({ flex: props.flex })
 );
@@ -37,7 +43,7 @@ render(
 			}}>
 				Some other text.
 			</span>
-			<YetAnotherComponent>Yet another text.</YetAnotherComponent>
+			<YetAnotherComponent>Yet <span>another</span> text.</YetAnotherComponent>
 		</AnotherComponent>
 	</SomeComponent>
 );

--- a/test/fixtures/emotion-10.jsx.json
+++ b/test/fixtures/emotion-10.jsx.json
@@ -232,6 +232,74 @@
 						},
 						{
 							"raws": {
+								"prop": {
+									"prefix": "[",
+									"suffix": "]",
+									"raw": "dynamicProp",
+									"value": "dynamicProp"
+								},
+								"value": {
+									"prefix": "'",
+									"suffix": "'",
+									"raw": "4px",
+									"value": "4px"
+								},
+								"between": ": ",
+								"before": "\n\t\t"
+							},
+							"prop": "dynamicProp",
+							"value": "4px",
+							"type": "decl",
+							"source": {
+								"input": {
+									"file": "emotion-10.jsx"
+								},
+								"start": {
+									"line": 20,
+									"column": 2
+								},
+								"end": {
+									"line": 20,
+									"column": 22
+								}
+							}
+						},
+						{
+							"raws": {
+								"prop": {
+									"prefix": "[`",
+									"suffix": "`]",
+									"raw": "${dynamicProp}-gap",
+									"value": "${dynamicProp}-gap"
+								},
+								"value": {
+									"prefix": "'",
+									"suffix": "'",
+									"raw": "4px",
+									"value": "4px"
+								},
+								"between": ": ",
+								"before": "\n\t\t"
+							},
+							"prop": "${dynamicProp}-gap",
+							"value": "4px",
+							"type": "decl",
+							"source": {
+								"input": {
+									"file": "emotion-10.jsx"
+								},
+								"start": {
+									"line": 21,
+									"column": 2
+								},
+								"end": {
+									"line": 21,
+									"column": 31
+								}
+							}
+						},
+						{
+							"raws": {
 								"selector": {
 									"prefix": "[",
 									"suffix": "]",
@@ -271,11 +339,11 @@
 											"file": "emotion-10.jsx"
 										},
 										"start": {
-											"line": 21,
+											"line": 23,
 											"column": 3
 										},
 										"end": {
-											"line": 21,
+											"line": 23,
 											"column": 17
 										}
 									}
@@ -286,11 +354,11 @@
 									"file": "emotion-10.jsx"
 								},
 								"start": {
-									"line": 20,
+									"line": 22,
 									"column": 2
 								},
 								"end": {
-									"line": 22,
+									"line": 24,
 									"column": 3
 								}
 							}
@@ -336,11 +404,11 @@
 											"file": "emotion-10.jsx"
 										},
 										"start": {
-											"line": 24,
+											"line": 26,
 											"column": 3
 										},
 										"end": {
-											"line": 24,
+											"line": 26,
 											"column": 17
 										}
 									}
@@ -351,11 +419,11 @@
 									"file": "emotion-10.jsx"
 								},
 								"start": {
-									"line": 23,
+									"line": 25,
 									"column": 2
 								},
 								"end": {
-									"line": 25,
+									"line": 27,
 									"column": 3
 								}
 							}
@@ -401,11 +469,11 @@
 											"file": "emotion-10.jsx"
 										},
 										"start": {
-											"line": 27,
+											"line": 29,
 											"column": 3
 										},
 										"end": {
-											"line": 27,
+											"line": 29,
 											"column": 17
 										}
 									}
@@ -416,11 +484,11 @@
 									"file": "emotion-10.jsx"
 								},
 								"start": {
-									"line": 26,
+									"line": 28,
 									"column": 2
 								},
 								"end": {
-									"line": 28,
+									"line": 30,
 									"column": 3
 								}
 							}
@@ -435,7 +503,7 @@
 							"column": 1
 						},
 						"end": {
-							"line": 29,
+							"line": 31,
 							"column": 2
 						}
 					}
@@ -449,7 +517,7 @@
 					"file": "emotion-10.jsx"
 				},
 				"start": {
-					"line": 30,
+					"line": 32,
 					"column": 11
 				},
 				"inline": false,
@@ -491,11 +559,11 @@
 									"file": "emotion-10.jsx"
 								},
 								"start": {
-									"line": 30,
+									"line": 32,
 									"column": 13
 								},
 								"end": {
-									"line": 30,
+									"line": 32,
 									"column": 29
 								}
 							}
@@ -506,11 +574,11 @@
 							"file": "emotion-10.jsx"
 						},
 						"start": {
-							"line": 30,
+							"line": 32,
 							"column": 11
 						},
 						"end": {
-							"line": 30,
+							"line": 32,
 							"column": 31
 						}
 					}
@@ -532,14 +600,14 @@
 					"type": "decl",
 					"source": {
 						"start": {
-							"line": 37,
+							"line": 39,
 							"column": 5
 						},
 						"input": {
 							"file": "emotion-10.jsx"
 						},
 						"end": {
-							"line": 37,
+							"line": 39,
 							"column": 22
 						}
 					},
@@ -552,7 +620,7 @@
 					"file": "emotion-10.jsx"
 				},
 				"start": {
-					"line": 36,
+					"line": 38,
 					"column": 19
 				},
 				"inline": false,
@@ -567,7 +635,7 @@
 					"file": "emotion-10.jsx"
 				},
 				"start": {
-					"line": 41,
+					"line": 43,
 					"column": 14
 				},
 				"inline": false,
@@ -609,11 +677,11 @@
 									"file": "emotion-10.jsx"
 								},
 								"start": {
-									"line": 42,
+									"line": 44,
 									"column": 4
 								},
 								"end": {
-									"line": 42,
+									"line": 44,
 									"column": 23
 								}
 							}
@@ -624,11 +692,11 @@
 							"file": "emotion-10.jsx"
 						},
 						"start": {
-							"line": 41,
+							"line": 43,
 							"column": 14
 						},
 						"end": {
-							"line": 43,
+							"line": 45,
 							"column": 4
 						}
 					}
@@ -650,14 +718,14 @@
 					"type": "decl",
 					"source": {
 						"start": {
-							"line": 52,
+							"line": 54,
 							"column": 2
 						},
 						"input": {
 							"file": "emotion-10.jsx"
 						},
 						"end": {
-							"line": 52,
+							"line": 54,
 							"column": 22
 						}
 					},
@@ -670,7 +738,7 @@
 					"file": "emotion-10.jsx"
 				},
 				"start": {
-					"line": 51,
+					"line": 53,
 					"column": 21
 				},
 				"inline": false,

--- a/test/fixtures/emotion-10.jsx.json
+++ b/test/fixtures/emotion-10.jsx.json
@@ -126,20 +126,20 @@
 								"prop": {
 									"prefix": "",
 									"suffix": "",
-									"raw": "color",
-									"value": "color"
+									"raw": "backgroundColor",
+									"value": "background-color"
 								},
 								"value": {
 									"prefix": "\"",
 									"suffix": "\"",
-									"raw": "hotpink",
-									"value": "hotpink"
+									"raw": "black",
+									"value": "black"
 								},
 								"between": ": ",
 								"before": "\n\t\t"
 							},
-							"prop": "color",
-							"value": "hotpink",
+							"prop": "background-color",
+							"value": "black",
 							"type": "decl",
 							"source": {
 								"input": {
@@ -151,7 +151,7 @@
 								},
 								"end": {
 									"line": 13,
-									"column": 18
+									"column": 26
 								}
 							}
 						}
@@ -179,7 +179,147 @@
 					"file": "emotion-10.jsx"
 				},
 				"start": {
-					"line": 15,
+					"line": 18,
+					"column": 1
+				},
+				"inline": false,
+				"lang": "object-literal",
+				"syntax": {}
+			},
+			"type": "root",
+			"nodes": [
+				{
+					"raws": {
+						"after": "\n\t",
+						"semicolon": true,
+						"before": "\t"
+					},
+					"type": "object",
+					"nodes": [
+						{
+							"raws": {
+								"prop": {
+									"prefix": "",
+									"suffix": "",
+									"raw": "color",
+									"value": "color"
+								},
+								"value": {
+									"prefix": "\"",
+									"suffix": "\"",
+									"raw": "hotpink",
+									"value": "hotpink"
+								},
+								"between": ": ",
+								"before": "\n\t\t"
+							},
+							"prop": "color",
+							"value": "hotpink",
+							"type": "decl",
+							"source": {
+								"input": {
+									"file": "emotion-10.jsx"
+								},
+								"start": {
+									"line": 19,
+									"column": 2
+								},
+								"end": {
+									"line": 19,
+									"column": 18
+								}
+							}
+						},
+						{
+							"raws": {
+								"selector": {
+									"prefix": "[",
+									"suffix": "]",
+									"raw": "YetAnotherComponent",
+									"value": "YetAnotherComponent"
+								},
+								"between": ": ",
+								"after": "\n\t\t",
+								"semicolon": true,
+								"before": "\n\t\t"
+							},
+							"selector": "YetAnotherComponent",
+							"type": "rule",
+							"nodes": [
+								{
+									"raws": {
+										"prop": {
+											"prefix": "",
+											"suffix": "",
+											"raw": "color",
+											"value": "color"
+										},
+										"value": {
+											"prefix": "\"",
+											"suffix": "\"",
+											"raw": "white",
+											"value": "white"
+										},
+										"between": ": ",
+										"before": "\n\t\t\t"
+									},
+									"prop": "color",
+									"value": "white",
+									"type": "decl",
+									"source": {
+										"input": {
+											"file": "emotion-10.jsx"
+										},
+										"start": {
+											"line": 21,
+											"column": 3
+										},
+										"end": {
+											"line": 21,
+											"column": 17
+										}
+									}
+								}
+							],
+							"source": {
+								"input": {
+									"file": "emotion-10.jsx"
+								},
+								"start": {
+									"line": 20,
+									"column": 2
+								},
+								"end": {
+									"line": 22,
+									"column": 3
+								}
+							}
+						}
+					],
+					"source": {
+						"input": {
+							"file": "emotion-10.jsx"
+						},
+						"start": {
+							"line": 18,
+							"column": 1
+						},
+						"end": {
+							"line": 23,
+							"column": 2
+						}
+					}
+				}
+			]
+		},
+		{
+			"raws": {},
+			"source": {
+				"input": {
+					"file": "emotion-10.jsx"
+				},
+				"start": {
+					"line": 24,
 					"column": 11
 				},
 				"inline": false,
@@ -221,11 +361,11 @@
 									"file": "emotion-10.jsx"
 								},
 								"start": {
-									"line": 15,
+									"line": 24,
 									"column": 13
 								},
 								"end": {
-									"line": 15,
+									"line": 24,
 									"column": 29
 								}
 							}
@@ -236,11 +376,11 @@
 							"file": "emotion-10.jsx"
 						},
 						"start": {
-							"line": 15,
+							"line": 24,
 							"column": 11
 						},
 						"end": {
-							"line": 15,
+							"line": 24,
 							"column": 31
 						}
 					}
@@ -262,14 +402,14 @@
 					"type": "decl",
 					"source": {
 						"start": {
-							"line": 22,
+							"line": 31,
 							"column": 5
 						},
 						"input": {
 							"file": "emotion-10.jsx"
 						},
 						"end": {
-							"line": 22,
+							"line": 31,
 							"column": 22
 						}
 					},
@@ -282,7 +422,7 @@
 					"file": "emotion-10.jsx"
 				},
 				"start": {
-					"line": 21,
+					"line": 30,
 					"column": 19
 				},
 				"inline": false,
@@ -297,7 +437,7 @@
 					"file": "emotion-10.jsx"
 				},
 				"start": {
-					"line": 26,
+					"line": 35,
 					"column": 14
 				},
 				"inline": false,
@@ -339,11 +479,11 @@
 									"file": "emotion-10.jsx"
 								},
 								"start": {
-									"line": 27,
+									"line": 36,
 									"column": 4
 								},
 								"end": {
-									"line": 27,
+									"line": 36,
 									"column": 23
 								}
 							}
@@ -354,11 +494,11 @@
 							"file": "emotion-10.jsx"
 						},
 						"start": {
-							"line": 26,
+							"line": 35,
 							"column": 14
 						},
 						"end": {
-							"line": 28,
+							"line": 37,
 							"column": 4
 						}
 					}
@@ -380,14 +520,14 @@
 					"type": "decl",
 					"source": {
 						"start": {
-							"line": 36,
+							"line": 46,
 							"column": 2
 						},
 						"input": {
 							"file": "emotion-10.jsx"
 						},
 						"end": {
-							"line": 36,
+							"line": 46,
 							"column": 22
 						}
 					},
@@ -400,7 +540,7 @@
 					"file": "emotion-10.jsx"
 				},
 				"start": {
-					"line": 35,
+					"line": 45,
 					"column": 21
 				},
 				"inline": false,

--- a/test/fixtures/emotion-10.jsx.json
+++ b/test/fixtures/emotion-10.jsx.json
@@ -294,6 +294,136 @@
 									"column": 3
 								}
 							}
+						},
+						{
+							"raws": {
+								"selector": {
+									"prefix": "[`",
+									"suffix": "`]",
+									"raw": "${YetAnotherComponent} > span",
+									"value": "${YetAnotherComponent} > span"
+								},
+								"between": ": ",
+								"after": "\n\t\t",
+								"semicolon": true,
+								"before": "\n\t\t"
+							},
+							"selector": "${YetAnotherComponent} > span",
+							"type": "rule",
+							"nodes": [
+								{
+									"raws": {
+										"prop": {
+											"prefix": "",
+											"suffix": "",
+											"raw": "color",
+											"value": "color"
+										},
+										"value": {
+											"prefix": "\"",
+											"suffix": "\"",
+											"raw": "black",
+											"value": "black"
+										},
+										"between": ": ",
+										"before": "\n\t\t\t"
+									},
+									"prop": "color",
+									"value": "black",
+									"type": "decl",
+									"source": {
+										"input": {
+											"file": "emotion-10.jsx"
+										},
+										"start": {
+											"line": 24,
+											"column": 3
+										},
+										"end": {
+											"line": 24,
+											"column": 17
+										}
+									}
+								}
+							],
+							"source": {
+								"input": {
+									"file": "emotion-10.jsx"
+								},
+								"start": {
+									"line": 23,
+									"column": 2
+								},
+								"end": {
+									"line": 25,
+									"column": 3
+								}
+							}
+						},
+						{
+							"raws": {
+								"selector": {
+									"prefix": "\"",
+									"suffix": "\"",
+									"raw": "&:before",
+									"value": "&:before"
+								},
+								"between": ": ",
+								"after": "\n\t\t",
+								"semicolon": true,
+								"before": "\n\t\t"
+							},
+							"selector": "&:before",
+							"type": "rule",
+							"nodes": [
+								{
+									"raws": {
+										"prop": {
+											"prefix": "",
+											"suffix": "",
+											"raw": "content",
+											"value": "content"
+										},
+										"value": {
+											"prefix": "`",
+											"suffix": "`",
+											"raw": "'!'",
+											"value": "'!'"
+										},
+										"between": ": ",
+										"before": "\n\t\t\t"
+									},
+									"prop": "content",
+									"value": "'!'",
+									"type": "decl",
+									"source": {
+										"input": {
+											"file": "emotion-10.jsx"
+										},
+										"start": {
+											"line": 27,
+											"column": 3
+										},
+										"end": {
+											"line": 27,
+											"column": 17
+										}
+									}
+								}
+							],
+							"source": {
+								"input": {
+									"file": "emotion-10.jsx"
+								},
+								"start": {
+									"line": 26,
+									"column": 2
+								},
+								"end": {
+									"line": 28,
+									"column": 3
+								}
+							}
 						}
 					],
 					"source": {
@@ -305,7 +435,7 @@
 							"column": 1
 						},
 						"end": {
-							"line": 23,
+							"line": 29,
 							"column": 2
 						}
 					}
@@ -319,7 +449,7 @@
 					"file": "emotion-10.jsx"
 				},
 				"start": {
-					"line": 24,
+					"line": 30,
 					"column": 11
 				},
 				"inline": false,
@@ -361,11 +491,11 @@
 									"file": "emotion-10.jsx"
 								},
 								"start": {
-									"line": 24,
+									"line": 30,
 									"column": 13
 								},
 								"end": {
-									"line": 24,
+									"line": 30,
 									"column": 29
 								}
 							}
@@ -376,11 +506,11 @@
 							"file": "emotion-10.jsx"
 						},
 						"start": {
-							"line": 24,
+							"line": 30,
 							"column": 11
 						},
 						"end": {
-							"line": 24,
+							"line": 30,
 							"column": 31
 						}
 					}
@@ -402,14 +532,14 @@
 					"type": "decl",
 					"source": {
 						"start": {
-							"line": 31,
+							"line": 37,
 							"column": 5
 						},
 						"input": {
 							"file": "emotion-10.jsx"
 						},
 						"end": {
-							"line": 31,
+							"line": 37,
 							"column": 22
 						}
 					},
@@ -422,7 +552,7 @@
 					"file": "emotion-10.jsx"
 				},
 				"start": {
-					"line": 30,
+					"line": 36,
 					"column": 19
 				},
 				"inline": false,
@@ -437,7 +567,7 @@
 					"file": "emotion-10.jsx"
 				},
 				"start": {
-					"line": 35,
+					"line": 41,
 					"column": 14
 				},
 				"inline": false,
@@ -479,11 +609,11 @@
 									"file": "emotion-10.jsx"
 								},
 								"start": {
-									"line": 36,
+									"line": 42,
 									"column": 4
 								},
 								"end": {
-									"line": 36,
+									"line": 42,
 									"column": 23
 								}
 							}
@@ -494,11 +624,11 @@
 							"file": "emotion-10.jsx"
 						},
 						"start": {
-							"line": 35,
+							"line": 41,
 							"column": 14
 						},
 						"end": {
-							"line": 37,
+							"line": 43,
 							"column": 4
 						}
 					}
@@ -520,14 +650,14 @@
 					"type": "decl",
 					"source": {
 						"start": {
-							"line": 46,
+							"line": 52,
 							"column": 2
 						},
 						"input": {
 							"file": "emotion-10.jsx"
 						},
 						"end": {
-							"line": 46,
+							"line": 52,
 							"column": 22
 						}
 					},
@@ -540,7 +670,7 @@
 					"file": "emotion-10.jsx"
 				},
 				"start": {
-					"line": 45,
+					"line": 51,
 					"column": 21
 				},
 				"inline": false,

--- a/test/fixtures/glamorous.jsx
+++ b/test/fixtures/glamorous.jsx
@@ -8,6 +8,7 @@ const Component1 = glm.a(
 		// stylelint-disable-next-line
 		"unknownProperty1": "1.8em", // must not trigger any warnings
 		unknownProperty2: "1.8em", // must not trigger any warnings
+		[unknownProperty3]: "1.8em", // must not trigger any warnings
 		[`unknownPropertyaa${a}`]: "1.8em", // must not trigger any warnings
 		["unknownProperty" + 1 + "a"]: "1.8em", // must not trigger any warnings
 		display: "inline-block",

--- a/test/fixtures/glamorous.jsx.json
+++ b/test/fixtures/glamorous.jsx.json
@@ -189,10 +189,10 @@
 						{
 							"raws": {
 								"prop": {
-									"prefix": "[`",
-									"suffix": "`]",
-									"raw": "unknownPropertyaa${a}",
-									"value": "unknown-propertyaa${a}"
+									"prefix": "[",
+									"suffix": "]",
+									"raw": "unknownProperty3",
+									"value": "unknownProperty3"
 								},
 								"value": {
 									"prefix": "\"",
@@ -203,7 +203,7 @@
 								"between": ": ",
 								"before": "\n\t\t"
 							},
-							"prop": "unknown-propertyaa${a}",
+							"prop": "unknownProperty3",
 							"value": "1.8em",
 							"type": "decl",
 							"source": {
@@ -216,6 +216,63 @@
 								},
 								"end": {
 									"line": 11,
+									"column": 29
+								}
+							}
+						},
+						{
+							"raws": {
+								"left": " ",
+								"right": "",
+								"inline": true,
+								"before": " "
+							},
+							"text": "must not trigger any warnings",
+							"type": "comment",
+							"source": {
+								"input": {
+									"file": "glamorous.jsx"
+								},
+								"start": {
+									"line": 11,
+									"column": 31
+								},
+								"end": {
+									"line": 11,
+									"column": 63
+								}
+							}
+						},
+						{
+							"raws": {
+								"prop": {
+									"prefix": "[`",
+									"suffix": "`]",
+									"raw": "unknownPropertyaa${a}",
+									"value": "unknownPropertyaa${a}"
+								},
+								"value": {
+									"prefix": "\"",
+									"suffix": "\"",
+									"raw": "1.8em",
+									"value": "1.8em"
+								},
+								"between": ": ",
+								"before": "\n\t\t"
+							},
+							"prop": "unknownPropertyaa${a}",
+							"value": "1.8em",
+							"type": "decl",
+							"source": {
+								"input": {
+									"file": "glamorous.jsx"
+								},
+								"start": {
+									"line": 12,
+									"column": 2
+								},
+								"end": {
+									"line": 12,
 									"column": 36
 								}
 							}
@@ -234,11 +291,11 @@
 									"file": "glamorous.jsx"
 								},
 								"start": {
-									"line": 11,
+									"line": 12,
 									"column": 38
 								},
 								"end": {
-									"line": 11,
+									"line": 12,
 									"column": 70
 								}
 							}
@@ -249,7 +306,7 @@
 									"prefix": "[",
 									"suffix": "]",
 									"raw": "\"unknownProperty\" + 1 + \"a\"",
-									"value": "\"unknown-property\" + 1 + \"a\""
+									"value": "\"unknownProperty\" + 1 + \"a\""
 								},
 								"value": {
 									"prefix": "\"",
@@ -260,7 +317,7 @@
 								"between": ": ",
 								"before": "\n\t\t"
 							},
-							"prop": "\"unknown-property\" + 1 + \"a\"",
+							"prop": "\"unknownProperty\" + 1 + \"a\"",
 							"value": "1.8em",
 							"type": "decl",
 							"source": {
@@ -268,11 +325,11 @@
 									"file": "glamorous.jsx"
 								},
 								"start": {
-									"line": 12,
+									"line": 13,
 									"column": 2
 								},
 								"end": {
-									"line": 12,
+									"line": 13,
 									"column": 40
 								}
 							}
@@ -291,11 +348,11 @@
 									"file": "glamorous.jsx"
 								},
 								"start": {
-									"line": 12,
+									"line": 13,
 									"column": 42
 								},
 								"end": {
-									"line": 12,
+									"line": 13,
 									"column": 74
 								}
 							}
@@ -325,11 +382,11 @@
 									"file": "glamorous.jsx"
 								},
 								"start": {
-									"line": 13,
+									"line": 14,
 									"column": 2
 								},
 								"end": {
-									"line": 13,
+									"line": 14,
 									"column": 25
 								}
 							}
@@ -381,11 +438,11 @@
 											"file": "glamorous.jsx"
 										},
 										"start": {
-											"line": 15,
+											"line": 16,
 											"column": 3
 										},
 										"end": {
-											"line": 15,
+											"line": 16,
 											"column": 15
 										}
 									}
@@ -398,11 +455,11 @@
 									"file": "glamorous.jsx"
 								},
 								"start": {
-									"line": 14,
+									"line": 15,
 									"column": 2
 								},
 								"end": {
-									"line": 16,
+									"line": 17,
 									"column": 3
 								}
 							}
@@ -421,11 +478,11 @@
 									"file": "glamorous.jsx"
 								},
 								"start": {
-									"line": 17,
+									"line": 18,
 									"column": 2
 								},
 								"end": {
-									"line": 17,
+									"line": 18,
 									"column": 33
 								}
 							}
@@ -471,11 +528,11 @@
 											"file": "glamorous.jsx"
 										},
 										"start": {
-											"line": 19,
+											"line": 20,
 											"column": 3
 										},
 										"end": {
-											"line": 19,
+											"line": 20,
 											"column": 25
 										}
 									}
@@ -486,11 +543,11 @@
 									"file": "glamorous.jsx"
 								},
 								"start": {
-									"line": 18,
+									"line": 19,
 									"column": 2
 								},
 								"end": {
-									"line": 20,
+									"line": 21,
 									"column": 3
 								}
 							}
@@ -536,11 +593,11 @@
 											"file": "glamorous.jsx"
 										},
 										"start": {
-											"line": 22,
+											"line": 23,
 											"column": 3
 										},
 										"end": {
-											"line": 22,
+											"line": 23,
 											"column": 26
 										}
 									}
@@ -552,11 +609,11 @@
 									"file": "glamorous.jsx"
 								},
 								"start": {
-									"line": 21,
+									"line": 22,
 									"column": 2
 								},
 								"end": {
-									"line": 23,
+									"line": 24,
 									"column": 3
 								}
 							}
@@ -602,11 +659,11 @@
 											"file": "glamorous.jsx"
 										},
 										"start": {
-											"line": 25,
+											"line": 26,
 											"column": 3
 										},
 										"end": {
-											"line": 25,
+											"line": 26,
 											"column": 18
 										}
 									}
@@ -618,11 +675,11 @@
 									"file": "glamorous.jsx"
 								},
 								"start": {
-									"line": 24,
+									"line": 25,
 									"column": 2
 								},
 								"end": {
-									"line": 26,
+									"line": 27,
 									"column": 3
 								}
 							}
@@ -652,11 +709,11 @@
 									"file": "glamorous.jsx"
 								},
 								"start": {
-									"line": 27,
+									"line": 28,
 									"column": 2
 								},
 								"end": {
-									"line": 27,
+									"line": 28,
 									"column": 21
 								}
 							}
@@ -671,7 +728,7 @@
 							"column": 1
 						},
 						"end": {
-							"line": 28,
+							"line": 29,
 							"column": 2
 						}
 					}
@@ -685,7 +742,7 @@
 					"file": "glamorous.jsx"
 				},
 				"start": {
-					"line": 30,
+					"line": 31,
 					"column": 19
 				},
 				"inline": false,
@@ -727,11 +784,11 @@
 									"file": "glamorous.jsx"
 								},
 								"start": {
-									"line": 31,
+									"line": 32,
 									"column": 2
 								},
 								"end": {
-									"line": 31,
+									"line": 32,
 									"column": 26
 								}
 							}
@@ -750,11 +807,11 @@
 									"file": "glamorous.jsx"
 								},
 								"start": {
-									"line": 31,
+									"line": 32,
 									"column": 28
 								},
 								"end": {
-									"line": 31,
+									"line": 32,
 									"column": 43
 								}
 							}
@@ -770,11 +827,11 @@
 									"file": "glamorous.jsx"
 								},
 								"start": {
-									"line": 32,
+									"line": 33,
 									"column": 2
 								},
 								"end": {
-									"line": 32,
+									"line": 33,
 									"column": 20
 								}
 							}
@@ -804,11 +861,11 @@
 									"file": "glamorous.jsx"
 								},
 								"start": {
-									"line": 33,
+									"line": 34,
 									"column": 2
 								},
 								"end": {
-									"line": 33,
+									"line": 34,
 									"column": 37
 								}
 							}
@@ -819,11 +876,11 @@
 							"file": "glamorous.jsx"
 						},
 						"start": {
-							"line": 30,
+							"line": 31,
 							"column": 19
 						},
 						"end": {
-							"line": 34,
+							"line": 35,
 							"column": 2
 						}
 					}
@@ -837,7 +894,7 @@
 					"file": "glamorous.jsx"
 				},
 				"start": {
-					"line": 37,
+					"line": 38,
 					"column": 35
 				},
 				"inline": false,
@@ -879,11 +936,11 @@
 									"file": "glamorous.jsx"
 								},
 								"start": {
-									"line": 38,
+									"line": 39,
 									"column": 1
 								},
 								"end": {
-									"line": 38,
+									"line": 39,
 									"column": 26
 								}
 							}
@@ -913,11 +970,11 @@
 									"file": "glamorous.jsx"
 								},
 								"start": {
-									"line": 39,
+									"line": 40,
 									"column": 1
 								},
 								"end": {
-									"line": 39,
+									"line": 40,
 									"column": 31
 								}
 							}
@@ -947,11 +1004,11 @@
 									"file": "glamorous.jsx"
 								},
 								"start": {
-									"line": 40,
+									"line": 41,
 									"column": 1
 								},
 								"end": {
-									"line": 40,
+									"line": 41,
 									"column": 14
 								}
 							}
@@ -962,11 +1019,11 @@
 							"file": "glamorous.jsx"
 						},
 						"start": {
-							"line": 37,
+							"line": 38,
 							"column": 35
 						},
 						"end": {
-							"line": 41,
+							"line": 42,
 							"column": 1
 						}
 					}
@@ -980,7 +1037,7 @@
 					"file": "glamorous.jsx"
 				},
 				"start": {
-					"line": 41,
+					"line": 42,
 					"column": 13
 				},
 				"inline": false,
@@ -1022,11 +1079,11 @@
 									"file": "glamorous.jsx"
 								},
 								"start": {
-									"line": 42,
+									"line": 43,
 									"column": 1
 								},
 								"end": {
-									"line": 42,
+									"line": 43,
 									"column": 39
 								}
 							}
@@ -1045,11 +1102,11 @@
 									"file": "glamorous.jsx"
 								},
 								"start": {
-									"line": 42,
+									"line": 43,
 									"column": 41
 								},
 								"end": {
-									"line": 42,
+									"line": 43,
 									"column": 71
 								}
 							}
@@ -1079,11 +1136,11 @@
 									"file": "glamorous.jsx"
 								},
 								"start": {
-									"line": 43,
+									"line": 44,
 									"column": 1
 								},
 								"end": {
-									"line": 43,
+									"line": 44,
 									"column": 30
 								}
 							}
@@ -1094,11 +1151,11 @@
 							"file": "glamorous.jsx"
 						},
 						"start": {
-							"line": 41,
+							"line": 42,
 							"column": 13
 						},
 						"end": {
-							"line": 44,
+							"line": 45,
 							"column": 1
 						}
 					}
@@ -1112,7 +1169,7 @@
 					"file": "glamorous.jsx"
 				},
 				"start": {
-					"line": 46,
+					"line": 47,
 					"column": 27
 				},
 				"inline": false,
@@ -1154,11 +1211,11 @@
 									"file": "glamorous.jsx"
 								},
 								"start": {
-									"line": 47,
+									"line": 48,
 									"column": 1
 								},
 								"end": {
-									"line": 47,
+									"line": 48,
 									"column": 20
 								}
 							}
@@ -1174,11 +1231,11 @@
 									"file": "glamorous.jsx"
 								},
 								"start": {
-									"line": 48,
+									"line": 49,
 									"column": 1
 								},
 								"end": {
-									"line": 48,
+									"line": 49,
 									"column": 14
 								}
 							}
@@ -1189,11 +1246,11 @@
 							"file": "glamorous.jsx"
 						},
 						"start": {
-							"line": 46,
+							"line": 47,
 							"column": 27
 						},
 						"end": {
-							"line": 49,
+							"line": 50,
 							"column": 1
 						}
 					}

--- a/test/fixtures/react-emotion.jsx
+++ b/test/fixtures/react-emotion.jsx
@@ -18,6 +18,12 @@ const AnotherComponent = styled("h1")(
 		[YetAnotherComponent]: {
 			color: "white",
 		},
+		[`${YetAnotherComponent} > span`]: {
+			color: "black",
+		},
+		"&:before": {
+			content: `'!'`,
+		},
 	},
 	props => ({ flex: props.flex })
 );

--- a/test/fixtures/react-emotion.jsx
+++ b/test/fixtures/react-emotion.jsx
@@ -6,9 +6,18 @@ const SomeComponent = styled("div")`
 	background-color: ${props => props.color};
 `;
 
+const YetAnotherComponent = styled.p(
+	{
+		backgroundColor: "black",
+	},
+);
+
 const AnotherComponent = styled("h1")(
 	{
 		color: "hotpink",
+		[YetAnotherComponent]: {
+			color: "white",
+		},
 	},
 	props => ({ flex: props.flex })
 );
@@ -18,6 +27,7 @@ render(
 		<AnotherComponent flex={1}>
 			Some text.
 		</AnotherComponent>
+		<YetAnotherComponent>Yet another text.</YetAnotherComponent>
 	</SomeComponent>
 );
 const app = document.getElementById("root");

--- a/test/fixtures/react-emotion.jsx
+++ b/test/fixtures/react-emotion.jsx
@@ -15,6 +15,8 @@ const YetAnotherComponent = styled.p(
 const AnotherComponent = styled("h1")(
 	{
 		color: "hotpink",
+		[dynamicProp]: '4px',
+		[`${dynamicProp}-gap`]: '4px',
 		[YetAnotherComponent]: {
 			color: "white",
 		},

--- a/test/fixtures/react-emotion.jsx.json
+++ b/test/fixtures/react-emotion.jsx.json
@@ -126,20 +126,20 @@
 								"prop": {
 									"prefix": "",
 									"suffix": "",
-									"raw": "color",
-									"value": "color"
+									"raw": "backgroundColor",
+									"value": "background-color"
 								},
 								"value": {
 									"prefix": "\"",
 									"suffix": "\"",
-									"raw": "hotpink",
-									"value": "hotpink"
+									"raw": "black",
+									"value": "black"
 								},
 								"between": ": ",
 								"before": "\n\t\t"
 							},
-							"prop": "color",
-							"value": "hotpink",
+							"prop": "background-color",
+							"value": "black",
 							"type": "decl",
 							"source": {
 								"input": {
@@ -151,7 +151,7 @@
 								},
 								"end": {
 									"line": 11,
-									"column": 18
+									"column": 26
 								}
 							}
 						}
@@ -179,7 +179,147 @@
 					"file": "react-emotion.jsx"
 				},
 				"start": {
-					"line": 13,
+					"line": 16,
+					"column": 1
+				},
+				"inline": false,
+				"lang": "object-literal",
+				"syntax": {}
+			},
+			"type": "root",
+			"nodes": [
+				{
+					"raws": {
+						"after": "\n\t",
+						"semicolon": true,
+						"before": "\t"
+					},
+					"type": "object",
+					"nodes": [
+						{
+							"raws": {
+								"prop": {
+									"prefix": "",
+									"suffix": "",
+									"raw": "color",
+									"value": "color"
+								},
+								"value": {
+									"prefix": "\"",
+									"suffix": "\"",
+									"raw": "hotpink",
+									"value": "hotpink"
+								},
+								"between": ": ",
+								"before": "\n\t\t"
+							},
+							"prop": "color",
+							"value": "hotpink",
+							"type": "decl",
+							"source": {
+								"input": {
+									"file": "react-emotion.jsx"
+								},
+								"start": {
+									"line": 17,
+									"column": 2
+								},
+								"end": {
+									"line": 17,
+									"column": 18
+								}
+							}
+						},
+						{
+							"raws": {
+								"selector": {
+									"prefix": "[",
+									"suffix": "]",
+									"raw": "YetAnotherComponent",
+									"value": "YetAnotherComponent"
+								},
+								"between": ": ",
+								"after": "\n\t\t",
+								"semicolon": true,
+								"before": "\n\t\t"
+							},
+							"selector": "YetAnotherComponent",
+							"type": "rule",
+							"nodes": [
+								{
+									"raws": {
+										"prop": {
+											"prefix": "",
+											"suffix": "",
+											"raw": "color",
+											"value": "color"
+										},
+										"value": {
+											"prefix": "\"",
+											"suffix": "\"",
+											"raw": "white",
+											"value": "white"
+										},
+										"between": ": ",
+										"before": "\n\t\t\t"
+									},
+									"prop": "color",
+									"value": "white",
+									"type": "decl",
+									"source": {
+										"input": {
+											"file": "react-emotion.jsx"
+										},
+										"start": {
+											"line": 19,
+											"column": 3
+										},
+										"end": {
+											"line": 19,
+											"column": 17
+										}
+									}
+								}
+							],
+							"source": {
+								"input": {
+									"file": "react-emotion.jsx"
+								},
+								"start": {
+									"line": 18,
+									"column": 2
+								},
+								"end": {
+									"line": 20,
+									"column": 3
+								}
+							}
+						}
+					],
+					"source": {
+						"input": {
+							"file": "react-emotion.jsx"
+						},
+						"start": {
+							"line": 16,
+							"column": 1
+						},
+						"end": {
+							"line": 21,
+							"column": 2
+						}
+					}
+				}
+			]
+		},
+		{
+			"raws": {},
+			"source": {
+				"input": {
+					"file": "react-emotion.jsx"
+				},
+				"start": {
+					"line": 22,
 					"column": 11
 				},
 				"inline": false,
@@ -221,11 +361,11 @@
 									"file": "react-emotion.jsx"
 								},
 								"start": {
-									"line": 13,
+									"line": 22,
 									"column": 13
 								},
 								"end": {
-									"line": 13,
+									"line": 22,
 									"column": 29
 								}
 							}
@@ -236,11 +376,11 @@
 							"file": "react-emotion.jsx"
 						},
 						"start": {
-							"line": 13,
+							"line": 22,
 							"column": 11
 						},
 						"end": {
-							"line": 13,
+							"line": 22,
 							"column": 31
 						}
 					}
@@ -262,14 +402,14 @@
 					"type": "decl",
 					"source": {
 						"start": {
-							"line": 25,
+							"line": 35,
 							"column": 2
 						},
 						"input": {
 							"file": "react-emotion.jsx"
 						},
 						"end": {
-							"line": 25,
+							"line": 35,
 							"column": 22
 						}
 					},
@@ -282,7 +422,7 @@
 					"file": "react-emotion.jsx"
 				},
 				"start": {
-					"line": 24,
+					"line": 34,
 					"column": 21
 				},
 				"inline": false,

--- a/test/fixtures/react-emotion.jsx.json
+++ b/test/fixtures/react-emotion.jsx.json
@@ -294,6 +294,136 @@
 									"column": 3
 								}
 							}
+						},
+						{
+							"raws": {
+								"selector": {
+									"prefix": "[`",
+									"suffix": "`]",
+									"raw": "${YetAnotherComponent} > span",
+									"value": "${YetAnotherComponent} > span"
+								},
+								"between": ": ",
+								"after": "\n\t\t",
+								"semicolon": true,
+								"before": "\n\t\t"
+							},
+							"selector": "${YetAnotherComponent} > span",
+							"type": "rule",
+							"nodes": [
+								{
+									"raws": {
+										"prop": {
+											"prefix": "",
+											"suffix": "",
+											"raw": "color",
+											"value": "color"
+										},
+										"value": {
+											"prefix": "\"",
+											"suffix": "\"",
+											"raw": "black",
+											"value": "black"
+										},
+										"between": ": ",
+										"before": "\n\t\t\t"
+									},
+									"prop": "color",
+									"value": "black",
+									"type": "decl",
+									"source": {
+										"input": {
+											"file": "react-emotion.jsx"
+										},
+										"start": {
+											"line": 22,
+											"column": 3
+										},
+										"end": {
+											"line": 22,
+											"column": 17
+										}
+									}
+								}
+							],
+							"source": {
+								"input": {
+									"file": "react-emotion.jsx"
+								},
+								"start": {
+									"line": 21,
+									"column": 2
+								},
+								"end": {
+									"line": 23,
+									"column": 3
+								}
+							}
+						},
+						{
+							"raws": {
+								"selector": {
+									"prefix": "\"",
+									"suffix": "\"",
+									"raw": "&:before",
+									"value": "&:before"
+								},
+								"between": ": ",
+								"after": "\n\t\t",
+								"semicolon": true,
+								"before": "\n\t\t"
+							},
+							"selector": "&:before",
+							"type": "rule",
+							"nodes": [
+								{
+									"raws": {
+										"prop": {
+											"prefix": "",
+											"suffix": "",
+											"raw": "content",
+											"value": "content"
+										},
+										"value": {
+											"prefix": "`",
+											"suffix": "`",
+											"raw": "'!'",
+											"value": "'!'"
+										},
+										"between": ": ",
+										"before": "\n\t\t\t"
+									},
+									"prop": "content",
+									"value": "'!'",
+									"type": "decl",
+									"source": {
+										"input": {
+											"file": "react-emotion.jsx"
+										},
+										"start": {
+											"line": 25,
+											"column": 3
+										},
+										"end": {
+											"line": 25,
+											"column": 17
+										}
+									}
+								}
+							],
+							"source": {
+								"input": {
+									"file": "react-emotion.jsx"
+								},
+								"start": {
+									"line": 24,
+									"column": 2
+								},
+								"end": {
+									"line": 26,
+									"column": 3
+								}
+							}
 						}
 					],
 					"source": {
@@ -305,7 +435,7 @@
 							"column": 1
 						},
 						"end": {
-							"line": 21,
+							"line": 27,
 							"column": 2
 						}
 					}
@@ -319,7 +449,7 @@
 					"file": "react-emotion.jsx"
 				},
 				"start": {
-					"line": 22,
+					"line": 28,
 					"column": 11
 				},
 				"inline": false,
@@ -361,11 +491,11 @@
 									"file": "react-emotion.jsx"
 								},
 								"start": {
-									"line": 22,
+									"line": 28,
 									"column": 13
 								},
 								"end": {
-									"line": 22,
+									"line": 28,
 									"column": 29
 								}
 							}
@@ -376,11 +506,11 @@
 							"file": "react-emotion.jsx"
 						},
 						"start": {
-							"line": 22,
+							"line": 28,
 							"column": 11
 						},
 						"end": {
-							"line": 22,
+							"line": 28,
 							"column": 31
 						}
 					}
@@ -402,14 +532,14 @@
 					"type": "decl",
 					"source": {
 						"start": {
-							"line": 35,
+							"line": 41,
 							"column": 2
 						},
 						"input": {
 							"file": "react-emotion.jsx"
 						},
 						"end": {
-							"line": 35,
+							"line": 41,
 							"column": 22
 						}
 					},
@@ -422,7 +552,7 @@
 					"file": "react-emotion.jsx"
 				},
 				"start": {
-					"line": 34,
+					"line": 40,
 					"column": 21
 				},
 				"inline": false,

--- a/test/fixtures/react-emotion.jsx.json
+++ b/test/fixtures/react-emotion.jsx.json
@@ -232,6 +232,74 @@
 						},
 						{
 							"raws": {
+								"prop": {
+									"prefix": "[",
+									"suffix": "]",
+									"raw": "dynamicProp",
+									"value": "dynamicProp"
+								},
+								"value": {
+									"prefix": "'",
+									"suffix": "'",
+									"raw": "4px",
+									"value": "4px"
+								},
+								"between": ": ",
+								"before": "\n\t\t"
+							},
+							"prop": "dynamicProp",
+							"value": "4px",
+							"type": "decl",
+							"source": {
+								"input": {
+									"file": "react-emotion.jsx"
+								},
+								"start": {
+									"line": 18,
+									"column": 2
+								},
+								"end": {
+									"line": 18,
+									"column": 22
+								}
+							}
+						},
+						{
+							"raws": {
+								"prop": {
+									"prefix": "[`",
+									"suffix": "`]",
+									"raw": "${dynamicProp}-gap",
+									"value": "${dynamicProp}-gap"
+								},
+								"value": {
+									"prefix": "'",
+									"suffix": "'",
+									"raw": "4px",
+									"value": "4px"
+								},
+								"between": ": ",
+								"before": "\n\t\t"
+							},
+							"prop": "${dynamicProp}-gap",
+							"value": "4px",
+							"type": "decl",
+							"source": {
+								"input": {
+									"file": "react-emotion.jsx"
+								},
+								"start": {
+									"line": 19,
+									"column": 2
+								},
+								"end": {
+									"line": 19,
+									"column": 31
+								}
+							}
+						},
+						{
+							"raws": {
 								"selector": {
 									"prefix": "[",
 									"suffix": "]",
@@ -271,11 +339,11 @@
 											"file": "react-emotion.jsx"
 										},
 										"start": {
-											"line": 19,
+											"line": 21,
 											"column": 3
 										},
 										"end": {
-											"line": 19,
+											"line": 21,
 											"column": 17
 										}
 									}
@@ -286,11 +354,11 @@
 									"file": "react-emotion.jsx"
 								},
 								"start": {
-									"line": 18,
+									"line": 20,
 									"column": 2
 								},
 								"end": {
-									"line": 20,
+									"line": 22,
 									"column": 3
 								}
 							}
@@ -336,11 +404,11 @@
 											"file": "react-emotion.jsx"
 										},
 										"start": {
-											"line": 22,
+											"line": 24,
 											"column": 3
 										},
 										"end": {
-											"line": 22,
+											"line": 24,
 											"column": 17
 										}
 									}
@@ -351,11 +419,11 @@
 									"file": "react-emotion.jsx"
 								},
 								"start": {
-									"line": 21,
+									"line": 23,
 									"column": 2
 								},
 								"end": {
-									"line": 23,
+									"line": 25,
 									"column": 3
 								}
 							}
@@ -401,11 +469,11 @@
 											"file": "react-emotion.jsx"
 										},
 										"start": {
-											"line": 25,
+											"line": 27,
 											"column": 3
 										},
 										"end": {
-											"line": 25,
+											"line": 27,
 											"column": 17
 										}
 									}
@@ -416,11 +484,11 @@
 									"file": "react-emotion.jsx"
 								},
 								"start": {
-									"line": 24,
+									"line": 26,
 									"column": 2
 								},
 								"end": {
-									"line": 26,
+									"line": 28,
 									"column": 3
 								}
 							}
@@ -435,7 +503,7 @@
 							"column": 1
 						},
 						"end": {
-							"line": 27,
+							"line": 29,
 							"column": 2
 						}
 					}
@@ -449,7 +517,7 @@
 					"file": "react-emotion.jsx"
 				},
 				"start": {
-					"line": 28,
+					"line": 30,
 					"column": 11
 				},
 				"inline": false,
@@ -491,11 +559,11 @@
 									"file": "react-emotion.jsx"
 								},
 								"start": {
-									"line": 28,
+									"line": 30,
 									"column": 13
 								},
 								"end": {
-									"line": 28,
+									"line": 30,
 									"column": 29
 								}
 							}
@@ -506,11 +574,11 @@
 							"file": "react-emotion.jsx"
 						},
 						"start": {
-							"line": 28,
+							"line": 30,
 							"column": 11
 						},
 						"end": {
-							"line": 28,
+							"line": 30,
 							"column": 31
 						}
 					}
@@ -532,14 +600,14 @@
 					"type": "decl",
 					"source": {
 						"start": {
-							"line": 41,
+							"line": 43,
 							"column": 2
 						},
 						"input": {
 							"file": "react-emotion.jsx"
 						},
 						"end": {
-							"line": 41,
+							"line": 43,
 							"column": 22
 						}
 					},
@@ -552,7 +620,7 @@
 					"file": "react-emotion.jsx"
 				},
 				"start": {
-					"line": 40,
+					"line": 42,
 					"column": 21
 				},
 				"inline": false,


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #36.

> Is there anything in the PR that needs further explanation?

* Add new tests for glamourous & emotion fixtures with Object Styles(Style Objects)
* Add special case for ComputedPropertyName to save prefix/postfix info

Actually, the result goes wrong when the property key looks like `[Identifier]`.
The keys such as ``[`${Identifier} > span`]`` and `"&:before"` have been parsed correctly already (tested in glamorous test fixture).