### PR TITLE
Remove hardcoded transform from float to cssFloat

### DIFF
--- a/object-stringifier.js
+++ b/object-stringifier.js
@@ -26,10 +26,6 @@ class ObjectStringifier extends Stringifier {
 	decl(node, semicolon) {
 		let prop = this.rawValue(node, 'prop');
 
-		if (prop === 'float') {
-			prop = 'cssFloat';
-		}
-
 		let string = prop;
 
 		const isObjectShorthand = node.raws.node && node.raws.node.shorthand;

--- a/test/css-in-js.js
+++ b/test/css-in-js.js
@@ -128,7 +128,7 @@ describe('CSS in JS', () => {
 		`);
 	});
 
-	it('float', () => {
+	it('cssFloat', () => {
 		const code = `
 			import glm from 'glamorous';
 			const Component1 = glm.a({
@@ -148,21 +148,24 @@ describe('CSS in JS', () => {
 				cssFloat: "left",
 			});
 		`);
+	});
 
-		root.first.first.nodes = [
-			postcss.decl({
-				prop: 'float',
-				value: 'right',
-				raws: {
-					before: root.first.first.first.raws.before,
-				},
-			}),
-		];
+	it('float', () => {
+		const code = `
+			const component = styled(Btn)({
+				float: "left",
+			});
+		`;
+
+		const root = syntax.parse(code, {
+			from: '/fixtures/styled-float.jsx',
+		});
+
+		expect(root.first.first.first).toHaveProperty('prop', 'float');
 
 		expect(root.toString()).toBe(`
-			import glm from 'glamorous';
-			const Component1 = glm.a({
-				cssFloat: "right",
+			const component = styled(Btn)({
+				float: "left",
 			});
 		`);
 	});


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Fixes https://github.com/stylelint/stylelint/issues/4490

Please let me know if I should open an issue in this repository, it's marked as an upstream issue there but I could not find a corresponding ticket.

> Is there anything in the PR that needs further explanation?

The offending code has been around since the second commit and it's not explained, so I can only assume that it's to attempt to catch uses of the reserved Javascript keyword "float" and automatically transform them to "cssFloat", however given that it's currently causing issues that can break code on `--fix` it should be removed.

Misuse of the keyword can be caught by Javascript code analysis tools.

The test case this removes appears to be a roundabout way of sort of testing the following transformation (by removing the raw value for "cssFloat"). This case has been removed since it's testing for behaviour that, according to this issue, we don't want:

```
import glm from 'glamorous';
const Component1 = glm.a({
	-float: "left",
	+cssFloat: "left",
});
```