### PR TITLE
Add support for styled-jsx

### DIFF
--- a/extract.js
+++ b/extract.js
@@ -330,6 +330,21 @@ function literalParser(source, opts, styles) {
 				addObjectJob(path.get('value.expression'));
 			}
 		},
+		JSXElement: (path) => {
+			const ele = path.node.openingElement;
+
+			if (
+				ele.name.name === 'style' &&
+				!ele.selfClosing &&
+				ele.attributes.length &&
+				ele.attributes.find((it) => it.name.name === 'jsx') &&
+				path.node.children.length === 1
+			) {
+				const quasi = path.node.children[0].expression;
+
+				tplLiteral.add(quasi);
+			}
+		},
 		VariableDeclarator: (path) => {
 			variableDeclarator.set(path.node.id, path.node.init ? [path.get('init')] : []);
 		},

--- a/extract.js
+++ b/extract.js
@@ -331,18 +331,18 @@ function literalParser(source, opts, styles) {
 			}
 		},
 		JSXElement: (path) => {
-			const ele = path.node.openingElement;
-
 			if (
-				ele.name.name === 'style' &&
-				!ele.selfClosing &&
-				ele.attributes.length &&
-				ele.attributes.find((it) => it.name.name === 'jsx') &&
-				path.node.children.length === 1
+				path.node.openingElement.name.name === 'style' &&
+				!path.node.openingElement.selfClosing &&
+				path.node.openingElement.attributes.length &&
+				path.node.openingElement.attributes.find((it) => it.name.name === 'jsx') &&
+				path.node.children.length
 			) {
-				const quasi = path.node.children[0].expression;
-
-				tplLiteral.add(quasi);
+				path.node.children.forEach((n) => {
+					if (types.isJSXExpressionContainer(n) && types.isTemplateLiteral(n.expression)) {
+						tplLiteral.add(n.expression);
+					}
+				});
 			}
 		},
 		VariableDeclarator: (path) => {

--- a/test/styled-jsx.js
+++ b/test/styled-jsx.js
@@ -1,0 +1,155 @@
+'use strict';
+
+const syntax = require('../');
+
+describe('styled-jsx', () => {
+	it('basic', () => {
+		const code = [
+			"import * as React from 'react'",
+			'',
+			'export const App = () => {',
+			'	return (',
+			'		<div>',
+			'			<style jsx>{`',
+			'			.test-cls {',
+			'				color: #fff;',
+			'			}',
+			'			`}</style>',
+			'		</div>',
+			'	)',
+			'}',
+		].join('\n');
+		const document = syntax.parse(code, {
+			from: 'before.jsx',
+		});
+
+		expect(document.toString()).toBe(code);
+		expect(document.source).toHaveProperty('lang', 'jsx');
+		expect(document.nodes).toHaveLength(1);
+		expect(document.first.nodes).toHaveLength(1);
+		expect(document.first.first).toHaveProperty('selector', '.test-cls');
+		expect(document.first.first.nodes).toHaveLength(1);
+		expect(document.first.first.nodes[0]).toHaveProperty('type', 'decl');
+		expect(document.first.first.nodes[0]).toHaveProperty('prop', 'color');
+		expect(document.first.first.nodes[0]).toHaveProperty('value', '#fff');
+	});
+
+	it('interpolation with identifier', () => {
+		const code = [
+			"import * as React from 'react'",
+			'',
+			'const colorVar = "red"',
+			'',
+			'export const App = (props) => {',
+			'	return (',
+			'		<div>',
+			'			<style jsx global>{`',
+			'			.test-cls {',
+			'				color: #fff;',
+			'				background-color: ${colorVar};',
+			'				padding: ${props.large ? "50" : "20"}px;',
+			'			}',
+			'			`}</style>',
+			'		</div>',
+			'	)',
+			'}',
+		].join('\n');
+		const document = syntax.parse(code, {
+			from: undefined,
+		});
+
+		expect(document.toString()).toBe(code);
+		expect(document.source).toHaveProperty('lang', 'jsx');
+		expect(document.nodes).toHaveLength(1);
+		expect(document.first.first.nodes).toHaveLength(3);
+		expect(document.first.first.nodes[1]).toHaveProperty('value', '${colorVar}');
+		expect(document.first.first.nodes[2]).toHaveProperty('type', 'decl');
+	});
+
+	it('external style', () => {
+		const code = [
+			"import css from 'styled-jsx/css'",
+			'',
+			'export const button = css`',
+			'	button {',
+			'		color: hotpink;',
+			'	}',
+			'`',
+			'',
+			'export const body = css.global`body { margin: 0; }`',
+			'',
+			'export const link = css.resolve`a { color: green; }`',
+		].join('\n');
+		const document = syntax.parse(code, {
+			from: undefined,
+		});
+
+		expect(document.toString()).toBe(code);
+		expect(document.source).toHaveProperty('lang', 'jsx');
+		expect(document.nodes).toHaveLength(3);
+		expect(document.nodes[0].first).toHaveProperty('type', 'rule');
+		expect(document.nodes[0].first).toHaveProperty('selector', 'button');
+		expect(document.nodes[0].first.first).toHaveProperty('type', 'decl');
+		expect(document.nodes[1].first).toHaveProperty('type', 'rule');
+		expect(document.nodes[1].first.first).toHaveProperty('type', 'decl');
+		expect(document.nodes[2].first).toHaveProperty('type', 'rule');
+		expect(document.nodes[2].first.first).toHaveProperty('type', 'decl');
+	});
+
+	it('skip css syntax error', () => {
+		const code = [
+			"import * as React from 'react'",
+			'',
+			'const colorVar = "red"',
+			'',
+			'export const App = () => {',
+			'	return (',
+			'		<div>',
+			'			<style jsx>{`',
+			'			.test-cls {',
+			'				color: #fff;',
+			'				background-color: ${colorVar};',
+			'			',
+			'			`}</style>',
+			'		</div>',
+			'	)',
+			'}',
+		].join('\n');
+		const document = syntax({
+			css: 'safe-parser',
+		}).parse(code, {
+			from: 'styled-jsx-safe-parse.js',
+		});
+
+		expect(document.source).toHaveProperty('lang', 'jsx');
+		expect(document.nodes).toHaveLength(1);
+		expect(document.first.nodes).toHaveLength(1);
+		expect(document.first.first).toHaveProperty('selector', '.test-cls');
+	});
+
+	it('skip jsx syntax error', () => {
+		const code = [
+			"import * as React from 'react'",
+			'',
+			'const colorVar = "red"',
+			'',
+			'export const App = () => {',
+			'	return (',
+			'		<div>',
+			'			<style jsx>{`',
+			'			.test-cls {',
+			'				color: #fff;',
+			'				background-color: ${colorVar};',
+			'			}',
+			'			`}</s>',
+			'		</div>',
+			'	)',
+			'}',
+		].join('\n');
+		const document = syntax.parse(code, {
+			from: undefined,
+		});
+
+		expect(document.source).toHaveProperty('lang', 'jsx');
+	});
+});

--- a/test/styled-jsx.js
+++ b/test/styled-jsx.js
@@ -79,6 +79,9 @@ describe('styled-jsx', () => {
 			'export const body = css.global`body { margin: 0; }`',
 			'',
 			'export const link = css.resolve`a { color: green; }`',
+			'',
+			'const ele1 = <style jsx global>{button}</style>',
+			'const ele2 = <style jsx>{body}</style>',
 		].join('\n');
 		const document = syntax.parse(code, {
 			from: undefined,


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

https://github.com/stylelint/postcss-css-in-js/issues/335

> Is there anything in the PR that needs further explanation?

- Support styled-jsx syntax in jsx
``` jsx
const Button = props => (
  <button>
    {props.children}
    <style jsx>{`
      button {
        color: #999;
        display: inline-block;
        font-size: 2em;
      }
    `}</style>
    <style jsx>{`
      button {
        padding: ${'large' in props ? '50' : '20'}px;
        background: ${props.theme.background};
      }
    `}</style>
  </button>
)
```
PS: [external styles](https://github.com/vercel/styled-jsx#external-styles) already has been supported somehow.

- Add tests for all my use cases
